### PR TITLE
Switch answers_lowercase to answer_lowercase singular

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -65,7 +65,7 @@ en:
 
     last_answer_lowercase: last answer
     last_one_to_many_lowercase: last entry
-    answers_lowercase:
+    answer_lowercase:
       one: answer
       other: answers
     one_to_many_lowercase:

--- a/config/locales/client.es.yml
+++ b/config/locales/client.es.yml
@@ -51,7 +51,7 @@ es:
       already_voted: "Solo puedes votar una vez por pregunta."
 
     last_answer_lowercase: última respuesta
-    answers_lowercase:
+    answer_lowercase:
       one: respuesta
       other: respuestas
 

--- a/config/locales/client.fi.yml
+++ b/config/locales/client.fi.yml
@@ -51,7 +51,7 @@ fi:
       already_voted: "Voit äänestää vain yhtä vastausta tähän kysymykseen"
 
     last_answer_lowercase: viimeisin vastaus
-    answers_lowercase:
+    answer_lowercase:
       one: vastaus
       other: vastaukset
 

--- a/config/locales/client.it.yml
+++ b/config/locales/client.it.yml
@@ -51,7 +51,7 @@ it:
       already_voted: "Puoi votare una sola volta per domanda."
 
     last_answer_lowercase: ""
-    answers_lowercase:
+    answer_lowercase:
       one: ''
       other: ''
 

--- a/config/locales/client.zh_CN.yml
+++ b/config/locales/client.zh_CN.yml
@@ -49,6 +49,6 @@ zh_CN:
       already_voted: "每个问题您只能投票一次。"
 
     last_answer_lowercase: ""
-    answers_lowercase:
+    answer_lowercase:
       other: ''
 


### PR DESCRIPTION
Hey @angusmcleod - I noticed that the current version isn't correctly finding the i18n text for `answer_lowercase` after you added the `one_to_many` [case here](https://github.com/angusmcleod/discourse-question-answer/blob/7eaed0032a8a000fafafdbaaf860170864b3c6ff/assets/javascripts/discourse/initializers/qa-edits.js.es6#L483):
```h('h4', I18n.t(`${postType}_lowercase`, { count: attrs.answer_count }))```

![image](https://user-images.githubusercontent.com/11527560/49104128-362a2200-f24b-11e8-97c1-c5364cf29434.png)

Example:
https://discourse.angusmcleod.com.au/t/what-has-cities-but-no-houses-forests-but-no-trees-and-water-but-no-fish/55

Let me know if just switching to singular is acceptable.