### PR TITLE
Add voting limits

### DIFF
--- a/assets/javascripts/discourse/widgets/qa-post.js.es6
+++ b/assets/javascripts/discourse/widgets/qa-post.js.es6
@@ -38,7 +38,18 @@ export default createWidget('qa-post', {
       direction
     };
 
-    castVote({ vote });
-  }
+    castVote({ vote })
+      .then(result => {
+          if (result.can_vote) {
+            post.set('topic.can_vote', result.can_vote);
+          }
+          if (result.vote_count) {
+            post.set('topic.vote_count', result.vote_count);
+          }
+      });
 
+    if (!post.get('topic.can_vote')) {
+      return bootbox.alert(I18n.t('vote.user_over_limit'));
+    }
+  }
 });

--- a/assets/javascripts/discourse/widgets/qa-post.js.es6
+++ b/assets/javascripts/discourse/widgets/qa-post.js.es6
@@ -23,7 +23,7 @@ export default createWidget('qa-post', {
     const user = this.currentUser;
 
     if (post.get('topic.voted')) {
-      return bootbox.alert(I18n.t('vote.already_voted'));
+      return bootbox.alert(I18n.t('vote.user_over_limit'));
     }
 
     if (!user) {

--- a/assets/javascripts/discourse/widgets/qa-post.js.es6
+++ b/assets/javascripts/discourse/widgets/qa-post.js.es6
@@ -38,14 +38,15 @@ export default createWidget('qa-post', {
       direction
     };
 
-    castVote({ vote })
-      .then(result => {
-          if (result.can_vote) {
-            post.set('topic.can_vote', result.can_vote);
-          }
-          if (result.vote_count) {
-            post.set('topic.vote_count', result.vote_count);
-          }
+    castVote({ 
+      vote 
+    }).then(result => {
+      if (result.can_vote) {
+        post.set('topic.can_vote', result.can_vote);
+      }
+      if (result.vote_count) {
+        post.set('topic.vote_count', result.vote_count);
+      }
     });
   }
 });

--- a/assets/javascripts/discourse/widgets/qa-post.js.es6
+++ b/assets/javascripts/discourse/widgets/qa-post.js.es6
@@ -22,7 +22,7 @@ export default createWidget('qa-post', {
     const post = this.attrs.post;
     const user = this.currentUser;
 
-    if (post.get('topic.voted')) {
+    if (!post.get('topic.can_vote')) {
       return bootbox.alert(I18n.t('vote.user_over_limit'));
     }
 

--- a/assets/javascripts/discourse/widgets/qa-post.js.es6
+++ b/assets/javascripts/discourse/widgets/qa-post.js.es6
@@ -46,10 +46,6 @@ export default createWidget('qa-post', {
           if (result.vote_count) {
             post.set('topic.vote_count', result.vote_count);
           }
-      });
-
-    if (!post.get('topic.can_vote')) {
-      return bootbox.alert(I18n.t('vote.user_over_limit'));
-    }
+    });
   }
 });

--- a/assets/javascripts/discourse/widgets/qa-post.js.es6
+++ b/assets/javascripts/discourse/widgets/qa-post.js.es6
@@ -19,15 +19,22 @@ export default createWidget('qa-post', {
   },
 
   vote(direction) {
-    const post = this.attrs.post;
     const user = this.currentUser;
+
+    if (!user) {
+      return this.sendShowLogin();
+    }
+
+    const post = this.attrs.post;
+    const siteSettings = this.siteSettings;
 
     if (!post.get('topic.can_vote')) {
       return bootbox.alert(I18n.t('vote.user_over_limit'));
     }
 
-    if (!user) {
-      return this.sendShowLogin();
+    if (!siteSettings.qa_allow_multiple_votes_per_post &&
+        post.get('topic.votes').indexOf(post.id) > -1) {
+      return bootbox.alert(I18n.t('vote.one_vote_per_post'));
     }
 
     post.set('topic.voted', true);
@@ -44,8 +51,8 @@ export default createWidget('qa-post', {
       if (result.can_vote) {
         post.set('topic.can_vote', result.can_vote);
       }
-      if (result.vote_count) {
-        post.set('topic.vote_count', result.vote_count);
+      if (result.votes) {
+        post.set('topic.votes', result.votes);
       }
     });
   }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -62,6 +62,7 @@ en:
 
     vote:
       already_voted: "You can only vote once per question."
+      user_over_limit: "You cannot exceed the number of votes for your trust level."
 
     last_answer_lowercase: last answer
     last_one_to_many_lowercase: last entry

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -63,6 +63,7 @@ en:
     vote:
       already_voted: "You can only vote once per question."
       user_over_limit: "You cannot exceed the number of votes for your trust level."
+      one_vote_per_post: "You can only vote once for each post."
 
     last_answer_lowercase: last answer
     last_one_to_many_lowercase: last entry

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -25,6 +25,9 @@ en:
           vote: "Undo vote"
         people:
           vote: "voted for this"
+          vote_capped:
+            one: "and {{count}} other voted for this"
+            other: "and {{count}} others voted for this"
         by_you:
           vote: "You voted for this post"
         by_you_and_others:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -7,6 +7,12 @@ en:
     qa_undo_vote_action_window: "Number of minutes users are allowed to undo votes in QnA topics (enter 0 for no limit)"
     qa_comments_default: "Maximum number of comments to display by default."
 
+    qa_tl1_vote_limit: "The vote limit for the question and answer plugin for trust level 1 users"
+    qa_tl2_vote_limit: "The vote limit for the question and answer plugin for trust level 2 users"
+    qa_tl3_vote_limit: "The vote limit for the question and answer plugin for trust level 3 users"
+    qa_tl4_vote_limit: "The vote limit for the question and answer plugin for trust level 4 users"
+
+
   post_action_types:
     vote:
       title: 'Vote'
@@ -17,5 +23,6 @@ en:
   vote:
     error:
       user_has_not_voted: "User has not voted."
+      user_over_limit: "You cannot exceed the number of votes for your trust level."
       already_voted: "You can only vote once per question."
       undo_vote_action_window: "You can only undo votes %{minutes} after voting."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -11,7 +11,8 @@ en:
     qa_tl2_vote_limit: "The vote limit for the question and answer plugin for trust level 2 users"
     qa_tl3_vote_limit: "The vote limit for the question and answer plugin for trust level 3 users"
     qa_tl4_vote_limit: "The vote limit for the question and answer plugin for trust level 4 users"
-
+    
+    qa_allow_multiple_votes_per_post: "Allow users to vote multiple times for the same post."
 
   post_action_types:
     vote:
@@ -26,3 +27,4 @@ en:
       user_over_limit: "You cannot exceed the number of votes for your trust level."
       already_voted: "You can only vote once per question."
       undo_vote_action_window: "You can only undo votes %{minutes} after voting."
+      one_vote_per_post: "You can only vote once for each post."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -21,3 +21,6 @@ plugins:
   qa_tl2_vote_limit: 3
   qa_tl3_vote_limit: 10
   qa_tl4_vote_limit: 100
+  qa_allow_multiple_votes_per_post:
+    default: false
+    client: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,3 +17,7 @@ plugins:
   qa_comments_default:
     default: 3
     client: true
+  qa_tl1_vote_limit: 1
+  qa_tl2_vote_limit: 3
+  qa_tl3_vote_limit: 10
+  qa_tl4_vote_limit: 100

--- a/lib/qa.rb
+++ b/lib/qa.rb
@@ -31,14 +31,14 @@ class QuestionAnswer::VotesController < ::ApplicationController
   before_action :ensure_qa_enabled, only: [:create, :destroy]
 
   def create
-
     if !Topic.can_vote(@post.topic, @user)
-        raise Discourse::InvalidAccess.new, I18n.t('vote.error.user_over_limit')
+      raise Discourse::InvalidAccess.new, I18n.t('vote.error.user_over_limit')
     end
 
     if QuestionAnswer::Vote.vote(@post, @user, vote_args)
       render json: success_json.merge(
-        vote_count: @post.vote_count
+        vote_count: Topic.vote_count(@post.topic, @user),
+        can_vote: Topic.can_vote(@post.topic, @user)
       )
     else
       render json: failed_json, status: 422
@@ -46,14 +46,14 @@ class QuestionAnswer::VotesController < ::ApplicationController
   end
 
   def destroy
-
     if Topic.vote_count(@post.topic, @user) == 0
-       raise Discourse::InvalidAccess.new, I18n.t('vote.error.user_has_not_voted')
+      raise Discourse::InvalidAccess.new, I18n.t('vote.error.user_has_not_voted')
     end
 
     if QuestionAnswer::Vote.vote(@post, @user, vote_args)
       render json: success_json.merge(
-        vote_count: @post.vote_count
+        vote_count: Topic.vote_count(@post.topic, @user),
+        can_vote: Topic.can_vote(@post.topic, @user)
       )
     else
       render json: failed_json, status: 422

--- a/lib/qa.rb
+++ b/lib/qa.rb
@@ -106,18 +106,18 @@ class QuestionAnswer::VotesController < ::ApplicationController
   end
 
   def ensure_can_act
-    if Topic.voted(@post.topic, @user)
-      if self.action_name === QuestionAnswer::Vote::CREATE
-        raise Discourse::InvalidAccess.new, I18n.t('vote.error.alread_voted')
-      end
 
-      if self.action_name === QuestionAnswer::Vote::DESTROY && !QuestionAnswer::Vote.can_undo(@post, @user)
-        raise Discourse::InvalidAccess.new, I18n.t('vote.error.undo_vote_action_window',
-          minutes: SiteSetting.qa_undo_vote_action_window
-        )
-      end
-    elsif self.action_name === QuestionAnswer::Vote::DESTROY
-      raise Discourse::InvalidAccess.new, I18n.t('vote.error.user_has_not_voted')
+    if Topic.can_vote(@post.topic, @user)
+        if Topic.vote_count(@post.topic, @user) >= vote_limit 
+            if self.action_name === QuestionAnswer::Vote::CREATE
+                raise Discourse::InvalidAccess.new, I18n.t('vote.error.user_over_limit')
+            end
+        end
+
+        if Topic.vote_count(@post.topic, @user) == 0
+            if self.action_name === QuestionAnswer::Vote::DESTROY
+            raise Discourse::InvalidAccess.new, I18n.t('vote.error.user_has_not_voted')
+        end
     end
   end
 end

--- a/lib/qa.rb
+++ b/lib/qa.rb
@@ -34,10 +34,14 @@ class QuestionAnswer::VotesController < ::ApplicationController
     if !Topic.can_vote(@post.topic, @user)
       raise Discourse::InvalidAccess.new, I18n.t('vote.error.user_over_limit')
     end
+    
+    if !@post.can_vote(@user.id)
+      raise Discourse::InvalidAccess.new, I18n.t('vote.error.one_vote_per_post')
+    end
 
     if QuestionAnswer::Vote.vote(@post, @user, vote_args)
       render json: success_json.merge(
-        vote_count: Topic.vote_count(@post.topic, @user),
+        votes: Topic.votes(@post.topic, @user),
         can_vote: Topic.can_vote(@post.topic, @user)
       )
     else
@@ -46,13 +50,13 @@ class QuestionAnswer::VotesController < ::ApplicationController
   end
 
   def destroy
-    if Topic.vote_count(@post.topic, @user) == 0
+    if Topic.votes(@post.topic, @user).length == 0
       raise Discourse::InvalidAccess.new, I18n.t('vote.error.user_has_not_voted')
     end
 
     if QuestionAnswer::Vote.vote(@post, @user, vote_args)
       render json: success_json.merge(
-        vote_count: Topic.vote_count(@post.topic, @user),
+        votes: Topic.votes(@post.topic, @user),
         can_vote: Topic.can_vote(@post.topic, @user)
       )
     else

--- a/lib/qa_post_edits.rb
+++ b/lib/qa_post_edits.rb
@@ -153,4 +153,9 @@ class ::Post
       nil
     end
   end
+  
+  def can_vote(user_id)
+    SiteSetting.qa_allow_multiple_votes_per_post ||
+    !voted.include?(user_id)
+  end
 end

--- a/lib/qa_topic_edits.rb
+++ b/lib/qa_topic_edits.rb
@@ -59,23 +59,18 @@ require_dependency 'topic'
 class ::Topic
   prepend TopicQAExtension
 
-  def self.voted(topic, user)
-    return nil if !user || !SiteSetting.qa_enabled
-    return nil if !self.can_vote(topic, user)
-  end
-
   def self.can_vote(topic, user)
     return nil if !user || !SiteSetting.qa_enabled
-    vote_count = self.vote_count(topic, user)
+    vote_count = self.votes(topic, user).length
     vote_limit = SiteSetting.send("qa_tl#{user.trust_level}_vote_limit")
     vote_limit >= vote_count
   end
 
-  def self.vote_count(topic, user)
+  def self.votes(topic, user)
     return nil if !user || !SiteSetting.qa_enabled
     PostCustomField.where(post_id: topic.posts.map(&:id),
                           name: 'voted',
-                          value: user.id).count
+                          value: user.id).pluck(:post_id)
   end
 
   def self.qa_enabled(topic)
@@ -150,8 +145,7 @@ require_dependency 'topic_view_serializer'
 require_dependency 'basic_user_serializer'
 class ::TopicViewSerializer
   attributes :qa_enabled,
-             :voted,
-             :vote_count,
+             :votes,
              :can_vote,
              :last_answered_at,
              :last_commented_on,
@@ -164,16 +158,12 @@ class ::TopicViewSerializer
     object.qa_enabled
   end
 
-  def voted
-    scope.current_user && ::Topic.voted(object.topic, scope.current_user)
-  end
-
-  def vote_count
-    Topic.vote_count(object.topic, scope.current_user)
+  def votes
+    Topic.votes(object.topic, scope.current_user)
   end
 
   def can_vote
-    ::Topic.can_vote(object.topic, scope.current_user)
+    Topic.can_vote(object.topic, scope.current_user)
   end
 
   def last_answered_at

--- a/lib/qa_topic_edits.rb
+++ b/lib/qa_topic_edits.rb
@@ -68,7 +68,7 @@ class ::Topic
     return nil if !user || !SiteSetting.qa_enabled
     vote_count = self.vote_count(topic, user)
     vote_limit = SiteSetting.send("qa_tl#{user.trust_level}_vote_limit")
-    vote_limit < vote_count
+    vote_limit >= vote_count
   end
 
   def self.vote_count(topic, user)


### PR DESCRIPTION
This is a first pass of changes required to add voting limits to the question and answer plugin, based on our discussion [here](https://discourse.angusmcleod.com.au/t/add-site-settings-for-vote-limits-according-to-trust-levels/1226/4). I've never developed in ruby (aside from using Jekyll) so thank you in advance for your guidance here! The changes below include the following (not yet tested because there is likely more fixes to do!)

 - I've added `qa_tl(1-4)_vote_limit` to the site settings, along with descriptors to server.en.yml. What about the other languages? Do users contribute content there as they use the plugin (and it's not available for their language?)
 - Along the way I noticed that the server.en.yml also has a vote -> errors sections, with strings that seem to be referenced in the server and client flow. I added a new one for `vote.user_over_limit`.
 - For the actual limits, it seems logical that we would want an untrusted user to have just 1, and then increase with increasing trust. (1,3,10, and then essentially (what seems to me would be) unlimited, 100)
 - I updated "ensure_can_act" to use the Topic.can_vote (which calls Topic.vote_count) to check if the user if at or above the limit. The vote_count function alone is used to see if the user hasn't voted at all.
 - I did my best to take a first shot at the actual functions to do the query, and then return a boolean to indicate if over the limit.
 - I updated the serializers, although it looks like they are both returning a boolean, and the count should probably return a count? How would that look?

```ruby
  def vote_count
    scope.current_user
    ::Topic.vote_count(object.topic, scope.current_user)
  end
```
Something like that?

Thanks for your help! I think I'm starting to pick up little things, which is fairly okay given only looking at ruby for about an hour now.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>